### PR TITLE
Do strip_tags() on posts content being pushed into sonic

### DIFF
--- a/src/Console/AddToIndex.php
+++ b/src/Console/AddToIndex.php
@@ -70,10 +70,11 @@ class AddToIndex extends AbstractCommand
         $progress = new ProgressBar($this->output, $posts->count());
         $progress->setFormat('verbose');
         foreach ($posts as $post) {
+            $start = microtime(true);
             try {
                 $ingest->push('postCollection', 'flarumBucket', $post->id, strip_tags($post->content), $locale);
             } catch (\Throwable $e) {
-                $this->error("{$post->id} with " . strip_tags($post->content) . ' bytes of content failed after' . round((microtime(true) - $start) * 1000, 2) . 'ms' . PHP_EOL);
+                $this->error("{$post->id} with " . strlen(strip_tags($post->content)) . ' bytes of content failed after ' . round((microtime(true) - $start) * 1000, 2) . 'ms' . PHP_EOL);
             } finally {
                 $progress->advance();
             }

--- a/src/Console/AddToIndex.php
+++ b/src/Console/AddToIndex.php
@@ -72,14 +72,16 @@ class AddToIndex extends AbstractCommand
         $progress->setFormat('verbose');
         foreach ($posts as $post) {
             $start = microtime(true);
-            try {
-                $ingest->push('postCollection', 'flarumBucket', $post->id, strip_tags($post->content), $locale);
-            } catch (\Throwable $e) {
-                $this->info(PHP_EOL);
-                $this->error("Post id {$post->id} with " . strlen(strip_tags($post->content)) . ' bytes of content failed after ' . round((microtime(true) - $start) * 1000, 2) . 'ms');
-            } finally {
-                $progress->advance();
+            $content = strip_tags($post->content);
+            if (trim($content) !== '') {
+                try {
+                    $ingest->push('postCollection', 'flarumBucket', $post->id, $content, $locale);
+                } catch (\Throwable $e) {
+                    $this->info(PHP_EOL);
+                    $this->error("Post id {$post->id} with " . strlen($content) . ' bytes of content failed after ' . round((microtime(true) - $start) * 1000, 2) . 'ms');
+                }
             }
+            $progress->advance();
         }
         $this->info($control->consolidate()); // saves the data to disk
         $ingest->disconnect();

--- a/src/Console/AddToIndex.php
+++ b/src/Console/AddToIndex.php
@@ -66,7 +66,8 @@ class AddToIndex extends AbstractCommand
             ->where('type', '=', 'comment')
             ->where('is_approved', 1)
             ->where('is_private', 0)
-            ->whereNull('hidden_at')->get();
+            ->whereNull('hidden_at')
+            ->get();
         $progress = new ProgressBar($this->output, $posts->count());
         $progress->setFormat('verbose');
         foreach ($posts as $post) {
@@ -74,7 +75,8 @@ class AddToIndex extends AbstractCommand
             try {
                 $ingest->push('postCollection', 'flarumBucket', $post->id, strip_tags($post->content), $locale);
             } catch (\Throwable $e) {
-                $this->error("{$post->id} with " . strlen(strip_tags($post->content)) . ' bytes of content failed after ' . round((microtime(true) - $start) * 1000, 2) . 'ms' . PHP_EOL);
+                $this->info(PHP_EOL);
+                $this->error("Post id {$post->id} with " . strlen(strip_tags($post->content)) . ' bytes of content failed after ' . round((microtime(true) - $start) * 1000, 2) . 'ms');
             } finally {
                 $progress->advance();
             }

--- a/src/Console/AddToIndex.php
+++ b/src/Console/AddToIndex.php
@@ -36,49 +36,46 @@ class AddToIndex extends AbstractCommand
     {
         $this->info('Starting...');
 
-        //$config = $this->container->make('flarum.config');
-        //$prefix = $config['database']['prefix'];
-        $locale = $this->settings->get('ganuonglachanh-sonic.locale','eng');
+        $locale = $this->settings->get('ganuonglachanh-sonic.locale', 'eng');
         $locale = $locale === '' ? 'eng' : $locale;
-        $password = $this->settings->get('ganuonglachanh-sonic.password','SecretPassword');
+        $password = $this->settings->get('ganuonglachanh-sonic.password', 'SecretPassword');
         $password = $password === '' ? 'SecretPassword' : $password;
-        $host = $this->settings->get('ganuonglachanh-sonic.host','127.0.0.1');
+        $host = $this->settings->get('ganuonglachanh-sonic.host', '127.0.0.1');
         $host = $host === '' ? '127.0.0.1' : $host;
-        $port = intval($this->settings->get('ganuonglachanh-sonic.port',1491));
+        $port = intval($this->settings->get('ganuonglachanh-sonic.port', 1491));
         $port = $port === 0 ? 1491 : $port;
-        $timeout = intval($this->settings->get('ganuonglachanh-sonic.timeout',30));
+        $timeout = intval($this->settings->get('ganuonglachanh-sonic.timeout', 30));
         $timeout = $timeout === 0 ? 30 : $timeout;
-        //https://github.com/ppshobi/psonic/blob/master/api-docs.md
-        $ingest  = new Ingest(new Client($host, $port, $timeout));
+        // https://github.com/ppshobi/psonic/blob/master/api-docs.md
+        $ingest = new Ingest(new Client($host, $port, $timeout));
         $control = new Control(new Client($host, $port, $timeout));
         try {
             $ingest->connect($password);
             $control->connect($password);
-        } catch (\Throwable $th) {
-            echo "\nInvalid sonic server detail!". PHP_EOL;
+        } catch (\Throwable $e) {
+            $this->error('Invalid sonic server detail!');
             return;
         }
         
-        echo 'Flush old postCollection: ' . $ingest->flushc('postCollection') . PHP_EOL;
-        echo "Adding to index...". PHP_EOL;
-        Post::select('id','content')
-            ->where('type','=', 'comment')
-            ->where('is_approved', 1)
-            ->where('is_private', 0)
-            ->whereNull('hidden_at')
-            ->chunk(200, function ($posts) use ($ingest, $locale) {
-                foreach ($posts as $post) {
-                    try {
-                        $ingest->push('postCollection', 'flarumBucket', $post->id, strip_tags($post->content), $locale);
-                    } catch (\Throwable $th) {
-                        echo "{$post->id} with " . strip_tags($post->content) . ' bytes of content failed after' . round((microtime(true) - $start) * 1000, 2) . 'ms' . PHP_EOL;
-                    }
+        $this->info('Flush old postCollection: ' . $ingest->flushc('postCollection'));
+        $this->info('Adding to index...');
+        $this->withProgressBar(
+            Post::select('id', 'content')
+                ->where('type', '=', 'comment')
+                ->where('is_approved', 1)
+                ->where('is_private', 0)
+                ->whereNull('hidden_at'),
+            function ($post) use ($ingest, $locale) {
+                try {
+                    $ingest->push('postCollection', 'flarumBucket', $post->id, strip_tags($post->content), $locale);
+                } catch (\Throwable $e) {
+                    $this->error("{$post->id} with " . strip_tags($post->content) . ' bytes of content failed after' . round((microtime(true) - $start) * 1000, 2) . 'ms' . PHP_EOL);
                 }
-            });
-        echo $control->consolidate(); // saves the data to disk
+            }
+        );
+        $this->info($control->consolidate()); // saves the data to disk
         $ingest->disconnect();
         $control->disconnect();
-        //echo json_encode($result);
-        echo "\nDone!". PHP_EOL;
+        $this->info('Done!');
     }
 }

--- a/src/Event/SonicEventSubscriber.php
+++ b/src/Event/SonicEventSubscriber.php
@@ -14,15 +14,15 @@ class SonicEventSubscriber
     public function __construct(SettingsRepositoryInterface $settings)
     {
         $this->settings = $settings;
-        $locale = $this->settings->get('ganuonglachanh-sonic.locale','eng');
+        $locale = $this->settings->get('ganuonglachanh-sonic.locale', 'eng');
         $this->locale = $locale === '' ? 'eng' : $locale;
-        $password = $this->settings->get('ganuonglachanh-sonic.password','SecretPassword');
+        $password = $this->settings->get('ganuonglachanh-sonic.password', 'SecretPassword');
         $this->password = $password === '' ? 'SecretPassword' : $password;
-        $host = $this->settings->get('ganuonglachanh-sonic.host','127.0.0.1');
+        $host = $this->settings->get('ganuonglachanh-sonic.host', '127.0.0.1');
         $host = $host === '' ? '127.0.0.1' : $host;
-        $port = intval($this->settings->get('ganuonglachanh-sonic.port',1491));
+        $port = intval($this->settings->get('ganuonglachanh-sonic.port', 1491));
         $port = $port === 0 ? 1491 : $port;
-        $timeout = intval($this->settings->get('ganuonglachanh-sonic.timeout',30));
+        $timeout = intval($this->settings->get('ganuonglachanh-sonic.timeout', 30));
         $timeout = $timeout === 0 ? 30 : $timeout;
         $this->ingest  = new \Psonic\Ingest(new \Psonic\Client($host, $port, $timeout));
         $this->control = new \Psonic\Control(new \Psonic\Client($host, $port, $timeout));
@@ -45,10 +45,10 @@ class SonicEventSubscriber
         if ($event->post->type === "comment") {
             try {
                 $this->ingest->connect($this->password);
-                $this->ingest->push('postCollection', 'flarumBucket', $event->post->id,$event->post->content, $this->locale);
+                $this->ingest->push('postCollection', 'flarumBucket', $event->post->id, strip_tags($event->post->content), $this->locale);
                 $this->ingest->disconnect();
-            } catch (\Throwable $th) {
-
+            } catch (\Throwable $e) {
+                app('log')->error($e);
             }
         }
     }
@@ -58,11 +58,11 @@ class SonicEventSubscriber
         if ($event->post->type === "comment") {
             try {
                 $this->ingest->connect($this->password);
-                //$this->ingest->pop('postCollection', 'flarumBucket', $event->post->id,$event->post->content);
-                $this->ingest->push('postCollection', 'flarumBucket', $event->post->id,$event->post->content, $this->locale);
+                //$this->ingest->pop('postCollection', 'flarumBucket', $event->post->id, strip_tags($event->post->content));
+                $this->ingest->push('postCollection', 'flarumBucket', $event->post->id, strip_tags($event->post->content), $this->locale);
                 $this->ingest->disconnect();
-            } catch (\Throwable $th) {
-                
+            } catch (\Throwable $e) {
+                app('log')->error($e);
             }
         }
     }
@@ -71,10 +71,10 @@ class SonicEventSubscriber
         if ($event->post->type === "comment") {
             try {
                 $this->ingest->connect($this->password);
-                $this->ingest->pop('postCollection', 'flarumBucket', $event->post->id,$event->post->content);
+                $this->ingest->pop('postCollection', 'flarumBucket', $event->post->id, strip_tags($event->post->content));
                 $this->ingest->disconnect();
-            } catch (\Throwable $th) {
-
+            } catch (\Throwable $e) {
+                app('log')->error($e);
             }
         }
     }
@@ -83,10 +83,10 @@ class SonicEventSubscriber
         if ($event->post->type === "comment") {
             try {
                 $this->ingest->connect($this->password);
-                $this->ingest->pop('postCollection', 'flarumBucket', $event->post->id,$event->post->content);
+                $this->ingest->pop('postCollection', 'flarumBucket', $event->post->id, strip_tags($event->post->content));
                 $this->ingest->disconnect();
-            } catch (\Throwable $th) {
-
+            } catch (\Throwable $e) {
+                app('log')->error($e);
             }
         }
     }
@@ -95,10 +95,10 @@ class SonicEventSubscriber
         if ($event->post->type === "comment") {
             try {
                 $this->ingest->connect($this->password);
-                $this->ingest->push('postCollection', 'flarumBucket', $event->post->id,$event->post->content, $this->locale);
+                $this->ingest->push('postCollection', 'flarumBucket', $event->post->id, strip_tags($event->post->content), $this->locale);
                 $this->ingest->disconnect();
-            } catch (\Throwable $th) {
-
+            } catch (\Throwable $e) {
+                app('log')->error($e);
             }
         }
     }


### PR DESCRIPTION
This will reduce probability of occurs #7 since content length is shorter after strip, also will produce more accurate search results (for now searching `"<t>"` or even a single `t` will results all posts due to they must be started with `<t>` xml tags)
End users should rerun the command `php flarum sonic:addtoindex` after applied this pr via `composer update`.

Also added a progress bar from symfony/console:
![image](https://user-images.githubusercontent.com/13030387/199598503-5269dcdf-bd0d-49b7-9206-079f017106fd.png)
